### PR TITLE
Fixes #286 Allows non english character based hashtags to be correctly identified.

### DIFF
--- a/app/js/filters/tweetHashtag.js
+++ b/app/js/filters/tweetHashtag.js
@@ -9,7 +9,7 @@ var filtersModule = require('./_index.js');
  filtersModule.filter('tweetHashtag', function () {
  	return function(input) {
  		var aTag = '<a class="external-hashtag" rel="external" href="./search?q=%23$1">#$1</a>';
- 		var hashtagReg = /#([\wäöå]+)/gi;
+ 		var hashtagReg = /#([^#^\ ^@]+)[\s,;]*/gi;
  		return input.replace(hashtagReg, aTag);
  	};
  });

--- a/app/js/filters/tweetHashtag.js
+++ b/app/js/filters/tweetHashtag.js
@@ -8,7 +8,7 @@ var filtersModule = require('./_index.js');
 
  filtersModule.filter('tweetHashtag', function () {
  	return function(input) {
- 		var aTag = '<a class="external-hashtag" rel="external" href="./search?q=%23$1">#$1</a>';
+ 		var aTag = '<a class="external-hashtag" rel="external" href="./search?q=%23$1">#$1</a>&nbsp;';
  		var hashtagReg = /#([^#^\ ^@]+)[\s,;]*/gi;
  		return input.replace(hashtagReg, aTag);
  	};


### PR DESCRIPTION
Sample string which passes the regex Strings previously used to break if àáâäæãåābçćčdèéêëēėęfghîïíīįìjkłmñńôöòóœøōõpqrßśštûüùúūvwxÿžźż were present.

Now it passes this too.