### PR TITLE
Modify to fit Connect button, enlarge fa icons, remove 'tweet' in mid…

### DIFF
--- a/app/styles/_topnav.scss
+++ b/app/styles/_topnav.scss
@@ -36,18 +36,25 @@
 			display: inline-block;
 			a {
 				display: inline-block;
-				padding: 15px 15px 10px 15px;
+				padding: 10px 15px 10px 15px;
+				@media (min-width: 768px) and (max-width: 991px) {
+				   	padding: 10px 6px 10px 8px !important;
+				}
 				line-height: 20px;
 				transition: all 0s ease-in-out;
-				color: black;	
+				color: rgb(102, 117, 127);	
 				&:hover, &.active-view-nav {
 					color: #55acee;
 					transition: all 0s ease-in-out;
 					border-bottom: 5px solid #55acee;
 					background: none;
 				}
-				span {
-					margin-right: 10px;
+				span.fa {
+					margin-right: 5px;
+					font-size: 24px;
+					position: relative;
+					top: 3px;
+					color: rgb(102, 117, 127);
 				}
 			}
 		}
@@ -224,6 +231,15 @@
 				margin-top: 5px;
 				background-color:#55acee;
 				color:white;
+				span.fa {
+					font-size: 26px;
+				}
+				span.text {
+					font-size: 14px;
+					position: relative;
+					bottom: 4px;
+					margin-left: 3px;
+				}
 			}
 		}
 	

--- a/app/views/topnav.html
+++ b/app/views/topnav.html
@@ -18,7 +18,7 @@
                     <li>
                         <button id="global-new-tweet-button" type="button" class="js-global-new-tweet js-tooltip btn primary-btn tweet-btn js-dynamic-tooltip" data-placement="bottom" data-component-term="new_tweet_button" data-original-title=""  data-toggle="modal" data-target="#myModal" >
                             <span class="fa fa-twitter"></span>
-                            <span class="text">Tweet</span>
+                            <span class="text hidden-xs hidden-sm hidden-md">Tweet</span>
                         </button>
                     </li>
                 </ul>
@@ -39,7 +39,7 @@
                 </div>
             </div>
             <!-- Hidden items -->
-            <div class="hidden-items hidden-sm hidden-sm hidden-lg hidden-init">
+            <div class="hidden-items hidden-sm hidden-md hidden-lg hidden-init">
                 <div class="list-of-views">
                     <ul>
                         <li ng-repeat="navItem in root.topNavItems">


### PR DESCRIPTION
Solve #239

Simple UX patch, live at http://gofullstack.me:3001/
- Icons are bigger, color is not complete black
![image](https://cloud.githubusercontent.com/assets/6878677/8592766/a2f0cb2c-263a-11e5-9a01-d964f4a803b6.png)
- On small, medium sizes, use only twitter icon, not `tweet` next. The items are also fit in one line
![image](https://cloud.githubusercontent.com/assets/6878677/8592799/e0f059ec-263a-11e5-92a1-6c3fcacee6ba.png)
- Icon size changes and color change apply for mobile size as well
![image](https://cloud.githubusercontent.com/assets/6878677/8592814/f2b3ab34-263a-11e5-8b0b-1fcf244ae1a2.png)


