### PR TITLE
Should solve #327

### DIFF
--- a/app/js/controllers/wallDisplay.js
+++ b/app/js/controllers/wallDisplay.js
@@ -409,6 +409,9 @@ function WallDisplay($scope, $stateParams, $interval, $timeout, $location, $http
 
     function calculateBins(labels, data){
         var binCount = 10;
+        if(labels.length<=binCount){
+            return({data:data,labels:labels});
+        }
         var intervalLength = Math.round(labels.length / binCount);
         var newData =[], newLabels = [];
         for (var i = 0; i < labels.length; i+=intervalLength) {


### PR DESCRIPTION
Issue #327  of freezing was caused due to a bug in the implementation of the
histogram binning algorithm. If the data returned by loklak_server was
smaller than the binCount, intervalLength would be set to 0, causing an
infinite loop. Fixed by returning the labels and data as is if they are
smaller than the binCount.

Link for testing:
http://localhost:3000//wall/display?data={%22headerColour%22:%22%232c88c9%22,%22headerPosition%22:%22Top%22,%22layoutStyle%22:%222%22,%22headerForeColour%22:%22%23FFFFFF%22,%22images%22:[%22both%22],%22videos%22:[%22both%22],%22audio%22:[%22both%22],%22allWords%22:[],%22anyWords%22:[],%22noWords%22:[],%22allHashtags%22:[],%22from%22:[],%22to%22:[],%22mentioning%22:[],%22eventName%22:%22MozWeekend%20Berlin%22,%22sinceDate%22:%222015-06-30T23:00:00.000Z%22,%22untilDate%22:%222015-07-22T00:00:00.000Z%22,%22mainHashtagText%22:%22mozweekend%22,%22mainHashtag%22:%22%23mozweekend%22,%22showStatistics%22:true}