### PR TITLE
New embed

### DIFF
--- a/app/js/controllers/search.js
+++ b/app/js/controllers/search.js
@@ -224,19 +224,21 @@ controllersModule.controller('SearchCtrl', ['$stateParams', '$rootScope', '$scop
     // HELPERS FN
     ///////////////////
     var bgUpdateTemp = function() {
-        var lastestDateObj = new Date(vm.statuses[0].created_at);
-        var term = ($rootScope.root.globalFilter === 'live') ? vm.term : vm.term + '+' + filterToQuery($rootScope.root.globalFilter);
-        SearchService.getData(term).then(function(data) {
-            var keepComparing = true; var i = 0;
-            while (keepComparing) {
-               if (new Date(data.statuses[i].created_at) <= lastestDateObj) {  
-                 vm.newStasuses = data.statuses.slice(0, i);
-                 vm.noOfNewStatuses = vm.newStasuses.length;
-                 keepComparing = false;
-               }
-               i++;
-            }
-        }, function() {});
+        if (vm.statuses[0]) {
+            var lastestDateObj = new Date(vm.statuses[0].created_at);
+            var term = ($rootScope.root.globalFilter === 'live') ? vm.term : vm.term + '+' + filterToQuery($rootScope.root.globalFilter);
+            SearchService.getData(term).then(function(data) {
+                var keepComparing = true; var i = 0;
+                while (keepComparing) {
+                   if (new Date(data.statuses[i].created_at) <= lastestDateObj) {  
+                     vm.newStasuses = data.statuses.slice(0, i);
+                     vm.noOfNewStatuses = vm.newStasuses.length;
+                     keepComparing = false;
+                   }
+                   i++;
+                }
+            }, function() {});    
+        }
     };
 
     var startNewInterval = function(period) {

--- a/app/js/directives/debugged-link.js
+++ b/app/js/directives/debugged-link.js
@@ -12,16 +12,12 @@ directivesModule.directive('debuggedLink', ['DebugLinkService', '$timeout', func
 	 * only when a thumbnail is available
 	 */
 	var generateArticleParts = function(data) {
-		if (!data.thumbnail_url) {
-			return false;
-		} else {
-			var author = (data.author && data.provider_name) ? '<a href="' + data.url + '" class="article-author">' + data.provider_name + ' - ' + data.author + '</a href="' + data.url + '">' : '';
-			var title = (data.title) ? '<a href="' + data.url + '" class="article-title">' + data.title  + '</a href="' + data.url + '">' : '';
-			var thumbnail = '<a href="' + data.url + '" class="article-img-container"><img src="' + data.thumbnail_url + '"></a href="' + data.url + '">';
-			var container = '<div class="article-container" href="' + data.url + '">';
+			var site = (data.site) ? '<a href="' + data.canonical + '" class="article-site">' + data.site + '</a>' : '';
+			var title = (data.title) ? '<a href="' + data.canonical + '" class="article-title">' + data.title  + '</a href="' + data.canonical + '">' : '';
+			var thumbnail = '<a href="' + data.canonical + '" class="article-img-container"><img src="' + data.thumbnail_url + '"></a href="' + data.canonical + '">';
+			var container = '<div class="article-container" href="' + data.canonical + '">';
 
-			return container + author + thumbnail + title + '</div>';
-		}		
+			return container + site + thumbnail + title + '</div>';	
 	};
 
 	/**
@@ -30,6 +26,68 @@ directivesModule.directive('debuggedLink', ['DebugLinkService', '$timeout', func
 	var generateMp4Template = function(src) {
 		return '<video width="100%"" style="min-height: 350px;" controls><source src="' + src + '" type="video/mp4">Your browser does not support HTML5 video.</video>';
 	};
+
+	/**
+	 * From iframely result, if data.html is not available
+	 * find html in links array
+	 * return html as result
+	*/
+	var findHtml = function(linkArray) {
+		var keepSearching = true;
+		var i = 0;
+		var result = false;
+		while (keepSearching && i < linkArray.length) {
+			var linkObj = linkArray[i];
+			for (var key in linkObj) {
+				if (key === "html") {
+					result = linkObj.html;
+					keepSearching = false;
+				}
+			}
+			i = i+1;
+		}
+		return result;
+	}
+
+	/**
+	 * From iframely result, if data.html is not available both in data root & data.link
+	 * find thumbnail
+	 * thumbnail with rel containing social media source has higher priority
+	 * for now the only high priority social source is twitter
+	*/
+	var findThumb = function(data) {
+
+		// Loop round 1 finding thumbnail that also has a social media rel
+		var keepSearching = true;
+		var i = 0;
+		var result = false;
+		while (keepSearching && i < data.links.length) {
+			var linkObj = data.links[i];;
+			if (linkObj.rel.indexOf("twitter") > -1 && linkObj.rel.indexOf("thumbnail") > -1) {
+				data.meta.thumbnail_url = linkObj.href;
+				result = data.meta;
+				keepSearching = false;
+			}
+			i = i+1;
+		}
+		if (result) {
+			return result; 
+		}
+
+		// Just find a thumbnail
+		var keepSearching = true;
+		var i = 0;
+		var result = false;
+		while (keepSearching && i < data.links.length) {
+			if (linkObj.rel.indexOf("thumbnail") > -1) {
+				data.meta.thumbnail_url = linkObj.href;
+				result = data.meta;
+				keepSearching = false;
+			}
+			i = i+1;
+		}
+		return result;
+	}
 
 	return {
 		restrict: 'A',
@@ -67,7 +125,27 @@ directivesModule.directive('debuggedLink', ['DebugLinkService', '$timeout', func
 					return;
 				} else if (undebuggedLink && undebuggedLink.indexOf("pic.twitter.com") === -1) {
 					DebugLinkService.debugLink(undebuggedLink).then(function(data) {
-						if (data !== "Page not found") {
+						var tagToAppend = "";
+						if (data.html) { // When embed is available and html is the only choice
+							tagToAppend = data.html;
+							scope.debuggable = true;
+						} else { // When embed is available and there are multiple choice
+							var detailedData = findHtml(data.links);
+							if (detailedData) {
+								tagToAppend = detailedData;
+							} else {
+								var moreDetailedData = findThumb(data);
+								if (moreDetailedData) {
+									tagToAppend = generateArticleParts(moreDetailedData);
+								}
+							}
+						}
+
+						if (tagToAppend) {
+							element.append(tagToAppend);
+							scope.debuggable = true;
+						}
+						/*if (data !== "Page not found") {
 							scope.debuggable = true;
 							if (data.type === "link" || data.type === "photo") {
 								// no html given, have to generate before append
@@ -83,7 +161,7 @@ directivesModule.directive('debuggedLink', ['DebugLinkService', '$timeout', func
 									element.append(data.html);
 								}
 							}
-						}
+						}*/
 					}, function() {scope.debuggable = false;});
 				}
 			}, 1000);	

--- a/app/js/services/debugLink.js
+++ b/app/js/services/debugLink.js
@@ -7,7 +7,8 @@ var servicesModule = require('./_index.js');
  */
 
 servicesModule.service('DebugLinkService',['$q', '$http', 'AppSettings', function($q, $http, AppSettings) {
-  //Given domain 
+
+  var defService = "/iframely";
 
   var getPosition = function(str, m, i) {
          return str.split(m, i).join(m).length;
@@ -27,7 +28,7 @@ servicesModule.service('DebugLinkService',['$q', '$http', 'AppSettings', functio
 
   service.debugLink = function(undebuggedLink) {
     var deferred = $q.defer();
-    var debugApiUrl = debugServiceApi + '/oembed';
+    var debugApiUrl = debugServiceApi + defService;
     $http.get(debugApiUrl, {
       params: {
         url: undebuggedLink,
@@ -42,7 +43,7 @@ servicesModule.service('DebugLinkService',['$q', '$http', 'AppSettings', functio
   };
 
   service.debugLinkSync = function(undebuggedLink) {
-    var query = debugServiceApi + '/oembed?url=' + encodeURIComponent(undebuggedLink);
+    var query = debugServiceApi + defService + '?url=' + encodeURIComponent(undebuggedLink);
     var request = new XMLHttpRequest();
     request.open('GET', query, false);  // `false` makes the request synchronous
     request.send(null);

--- a/app/views/status.html
+++ b/app/views/status.html
@@ -1,6 +1,6 @@
 <div ng-attr-id="{{data.id_str}}" ng-click="toggleDetail($event)" class="tweet tweet-simple">
 
-    <!-- Avatar with a fallback src -->
+    <!-- Avatar with a fallback -->
     <img fallback-status-id="data.user.screen_name" class="avatar" 
          fallback-src="/images/anon_200x200.png"
     	 ng-src="{{data.user.profile_image_url_https}}" alt="user-images">
@@ -24,25 +24,25 @@
                 <!-- Images - 1 img -->
                 <div data-ng-click="openSwipe(data.id_str);" ng-class="{'images-wrapper': true, 'clearfix': true, 'showdetail': showDetail}" ng-if="data.images_count === 1">
                         <div class="single-masonry-item" ng-repeat="image in data.images track by $index">
-                            <img ng-src="{{image}}" alt="A masonry brick">
+                            <img ng-src="{{(image) ? image : '/images/anon_200x200.png'}}">
                         </div>
                 </div>
                 <!-- Images - 2 imgs -->
                 <div data-ng-click="openSwipe(data.id_str);" ng-class="{'images-wrapper': true, 'clearfix': true, 'showdetail': showDetail, 'showcomposition' : true}" ng-if="data.images_count === 2">
                         <div class="double-masonry-item" ng-repeat="image in data.images track by $index">
-                            <img ng-src="{{image}}" alt="A masonry brick">
+                            <img ng-src="{{(image) ? image : '/images/anon_200x200.png'}}">
                         </div>
                 </div>
                 <!-- Images - 3 imgs -->
                 <div data-ng-click="openSwipe(data.id_str);" ng-class="{'images-wrapper': true, 'clearfix': true, 'showdetail': showDetail, 'showcomposition' : true}" ng-if="data.images_count === 3">
                         <div ng-class="{'triple-masonry-item': true, 'first-item': ($index === 0)}" ng-repeat="image in data.images track by $index">
-                            <img ng-src="{{image}}" alt="A masonry brick">
+                            <img ng-src="{{(image) ? image : '/images/anon_200x200.png'}}">
                         </div>
                 </div>
                 <!-- Images - 4 imgs -->
                 <div data-ng-click="openSwipe(data.id_str);" ng-class="{'images-wrapper': true, 'clearfix': true, 'showdetail': showDetail, 'showcomposition' : true}" ng-if="data.images_count === 4">
                         <div class="quad-masonry-item" ng-repeat="image in data.images track by $index">
-                            <img ng-src="{{image}}" alt="A masonry brick">
+                            <img ng-src="{{(image) ? image : '/images/anon_200x200.png'}}">
                         </div>
                 </div>
             </div>


### PR DESCRIPTION
Solve #354 and trivial things (add cases to prevent flood of warning, add fallback img for statuses as well). Biggest change is the debug engine. It was previously `Oembed`, now is changed to `Iframely` for more sophisticated result. Example of the effect, check tweet no. 2:
- Old version on live: http://test.loklak.net/search?q=%23mozweekend
- New version on my server: http://gofullstack.me:3001/search?q=%23mozweekend

In additions to rendering successfully the link, provider name of the articale is shown as well, e.g. `SitePoint`, `Github` etc