### PR TITLE
Issue#321

### DIFF
--- a/app/js/controllers/search.js
+++ b/app/js/controllers/search.js
@@ -183,7 +183,7 @@ controllersModule.controller('SearchCtrl', ['$stateParams', '$rootScope', '$scop
         updatePath(vm.term + '+' + '/map');
 
         var params = {
-            q: vm.term /*+ "+" + initialBound*/,
+            q: vm.term + "+" + initialBound,
             count: 300
         };
         SearchService.initData(params).then(function(data) {
@@ -194,7 +194,6 @@ controllersModule.controller('SearchCtrl', ['$stateParams', '$rootScope', '$scop
                 }
             })
             initMap(data.statuses);   
-            console.log(withoutLocation); 
             addUserLocation(withoutLocation);
         }, function() {});
 
@@ -374,7 +373,6 @@ controllersModule.controller('SearchCtrl', ['$stateParams', '$rootScope', '$scop
         noLocationStatuses.forEach(function(ele, index) {
             if (ele.user) {
                 SearchService.getUserInfo(ele.user.screen_name).then(function(userInfo) {
-                    console.log(userInfo);
                     if (userInfo.user && userInfo.user.location_mark) {
                         ele.location_mark = userInfo.user.location_mark;    
                     }

--- a/app/js/services/search.js
+++ b/app/js/services/search.js
@@ -70,7 +70,7 @@ function SearchService($q, $http, AppSettings) {
     var deferred = $q.defer();
     //paramsObj.q = decodeURIComponent(paramsObj.q);
     $http.jsonp(AppSettings.apiUrl+'account.json?callback=JSON_CALLBACK', {
-      params: {q: username}
+      params: {screen_name: username}
     }).success(function(data) {
         deferred.resolve(data);
     }).error(function(err, status) {

--- a/app/js/services/search.js
+++ b/app/js/services/search.js
@@ -66,6 +66,20 @@ function SearchService($q, $http, AppSettings) {
     return deferred.promise;
   };
 
+  service.getUserInfo = function(username) {
+    var deferred = $q.defer();
+    //paramsObj.q = decodeURIComponent(paramsObj.q);
+    $http.jsonp(AppSettings.apiUrl+'account.json?callback=JSON_CALLBACK', {
+      params: {q: username}
+    }).success(function(data) {
+        deferred.resolve(data);
+    }).error(function(err, status) {
+        deferred.reject(err, status);
+    });
+
+    return deferred.promise;
+  }
+
   return service;
 
 }


### PR DESCRIPTION
**PLEASE ONLY REVIEW THIS, DON'T MERGE**. I added some code for demonstration, those need to be removed before merge. 

This provides a fallback for #321 
Brief: some statuses don't have location. In that case, we take the user name and make a request to the server for more information. If location_mark is available, add it to the status, and then add it to the map.

This is hard to check because currently, all results from query containing `/location` have `location_mark`. However, I created a initial case for checking. How to check locally:
- Pull to branch => gulp dev
- Go to http://localhost:3000/search?q=%23loklak%2B%2Fmap 
- Open Dev console
- You can see an array of statuses without locations are separated, and for each of those statuses, there's a saparate request for more information:
![image](https://cloud.githubusercontent.com/assets/6878677/8828710/3487dd30-309c-11e5-9875-2f41145733bb.png)
- That's it :)

The map experience should be the same, those statuses without locations are not blocking the rendering of the map. They will be processes only after the ones with locations are finished rendering :)