### PR TITLE
Parse markdown in rich tweet

### DIFF
--- a/app/js/filters/parseNormalContent.js
+++ b/app/js/filters/parseNormalContent.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var filtersModule = require('./_index.js');
+var md = require("markdown");
+/**
+ * @ngInject
+ */
+
+function parseNormalContentFilter() {
+	return function(input) {
+	 	return input.split("\n***\n")[0];	
+	};
+}
+
+
+filtersModule.filter('parseNormalContent', [parseNormalContentFilter]);

--- a/app/js/filters/parseRichContent.js
+++ b/app/js/filters/parseRichContent.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var filtersModule = require('./_index.js');
+var md = require("markdown");
+window.markdown = md.markdown;
+/**
+ * @ngInject
+ */
+
+function parseRichContentFilter() {
+	return function(input) {
+		 if (input.indexOf("\n***\n") > -1) {
+		 	var richPart = input.split("\n***\n")[1];	
+		 	console.log(richPart);
+		 	return " " +  md.markdown.toHTML(richPart);
+		 } else {
+		 	return "";
+		 }
+	};
+}
+
+
+filtersModule.filter('parseRichContent', [parseRichContentFilter]);

--- a/app/styles/_search.scss
+++ b/app/styles/_search.scss
@@ -64,6 +64,19 @@
 			.tweet-content {
 				margin-left: 58px;
 				
+				.tweet-content-container {
+					p {
+						margin: 0 0 0 0;
+						display: inline;
+					}	
+					a {
+						&:hover {
+							cursor: pointer;
+							text-decoration: underline;
+						}
+					}
+					margin-bottom: 10px;
+				}
 				.tweet-content-text {
 					word-break: keep-all;
 					color: #292f33;
@@ -439,6 +452,19 @@
 						.screen-name, .created-at {
 							font-size: 13px;
 							color: #8899A6;
+						}
+						.tweet-content-container {
+							p {
+								margin: 0 0 0 0;
+								display: inline;
+							}	
+							a {
+								&:hover {
+									cursor: pointer;
+									text-decoration: underline;
+								}
+							}
+							margin-bottom: 10px;
 						}
 						.tweet-content-text {
 							word-break: keep-all;

--- a/app/views/status.html
+++ b/app/views/status.html
@@ -15,7 +15,11 @@
             <!-- End of metadata -->
 
             <!-- Text -->
-            <p class="tweet-content-text" ng-bind-html="data.text | tweetTextLink  | tweetMention | tweetHashtag | toTrusted"></p>
+            <div class="tweet-content-container">
+                <p class="tweet-content-text" ng-bind-html="data.text | parseNormalContent | tweetTextLink  | tweetMention | tweetHashtag | toTrusted"></p>
+                <p class="rich-tweet-content-text" ng-bind-html="data.text | parseRichContent | toTrusted"></p>
+            </div>
+            
 
             <div class="debugged-link-container" debugged-link data="data" image-link="data.images" link-array="data.links" debuggable="debuggable"></div>
 

--- a/package.json
+++ b/package.json
@@ -69,16 +69,17 @@
     "angular-loading-bar": "^0.7.1",
     "angular-moment": "^0.10.0",
     "bootstrap": "^3.3.4",
+    "browserify-shim": "^3.8.9",
     "chart.js": "^1.0.2",
     "gulp-nodemon": "^2.0.3",
     "jquery": "^2.1.4",
+    "jquery-browserify": "^1.8.1",
+    "markdown": "^0.5.0",
     "masonry-layout": "^3.3.0",
     "moment": "^2.10.2",
     "ng-tags-input": "^2.3.0",
     "sync-request": "^2.0.1",
-    "twitter-text": "^1.12.0",
-    "browserify-shim": "^3.8.9",
-    "jquery-browserify": "^1.8.1"
+    "twitter-text": "^1.12.0"
   },
   "browserify-shim": {
     "jQuery": "global:$",


### PR DESCRIPTION
Part of feature #100 
Basic mark down syntax is now parsed.
Live test:http://gofullstack.me:3001/search?q=%23richcontentweet

To check you own example, create a rich content tweet with markdown by:
- Input normal text
- new line, ***, and then new line
- Input mark down syntax  
[Like this status.](Like this status.)

