### PR TITLE
Map tiles can now be attached via loklak

### DIFF
--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -108,7 +108,7 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
             headers: {
                 'Content-Type': 'application/json; charset=utf-8'
             }
-        }).success(function(response) {
+        }).success(function (response) {
 
             var message = $rootScope.root.tweet;
             var tweetLen = twttr.txt.getTweetLength(message);
@@ -119,7 +119,7 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
                 hello('twitter').api('me/share', 'POST', {
                     message : message,
                     file : selectedFileInBlob
-                }).then(function(json) {
+                }).then( function (json) {
                     console.log(json);
                 }, function(e) {
                     console.log(e);
@@ -133,6 +133,35 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
         //         $rootScope.root.geoTile = response;
         //         console.log("Successful Query to "+requestUrl);
         //     });
+    }
+
+    $rootScope.root.tweetMarkdown = function() {
+
+        var message = $rootScope.root.tweet;
+
+        $http({
+            url: requestUrl,
+            method: "GET",
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+            }
+        }).success(function (response) {
+
+            var tweetLen = twttr.txt.getTweetLength(message);
+            var tweet = encodeURIComponent(message);
+
+            var selectedFileInBlob = FileService.Base64StrToBlobStr(response);
+            if(tweetLen <= 140 && tweetLen > 0) {
+                hello('twitter').api('me/share', 'POST', {
+                    message: '',
+                    file: selectedFileInBlob
+                }).then( function (json) {
+                    console.log(json);
+                }, function (e) {
+                    console.log(e);
+                });
+            }
+        })
     }
 
     $rootScope.root.retweet = function(id) {

--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -139,7 +139,7 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
 
         var message = $rootScope.root.tweet;
         var encodedMessage = encodeURIComponent(message);
-        var requestUrl = "http://localhost:9000/vis/markdown.png?text="+encodedMessage+"&color_text=000000&color_background=ffffff&padding=3"
+        var requestUrl = "http://localhost:9000/vis/markdown.png.base64?text="+encodedMessage+"&color_text=000000&color_background=ffffff&padding=3"
 
         $http({
             url: requestUrl,
@@ -150,19 +150,17 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
         }).success(function (response) {
 
             var tweetLen = twttr.txt.getTweetLength(message);
-            var tweet = encodeURIComponent(message);
 
             var selectedFileInBlob = FileService.Base64StrToBlobStr(response);
-            if(tweetLen <= 140 && tweetLen > 0) {
-                hello('twitter').api('me/share', 'POST', {
-                    message: '',
-                    file: selectedFileInBlob
-                }).then( function (json) {
-                    console.log(json);
-                }, function (e) {
-                    console.log(e);
-                });
-            }
+            
+            hello('twitter').api('me/share', 'POST', {
+                message: '',
+                file: selectedFileInBlob
+            }).then( function (json) {
+                console.log(json);
+            }, function (e) {
+                console.log(e);
+            });
         })
     }
 

--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -138,6 +138,8 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
     $rootScope.root.tweetMarkdown = function() {
 
         var message = $rootScope.root.tweet;
+        var encodedMessage = encodeURIComponent(message);
+        var requestUrl = "http://localhost:9000/vis/markdown.png?text="+encodedMessage+"&color_text=000000&color_background=ffffff&padding=3"
 
         $http({
             url: requestUrl,

--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -115,15 +115,16 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
             var tweet = encodeURIComponent(message);
 
             var selectedFileInBlob = FileService.Base64StrToBlobStr(response);
-
-            hello('twitter').api('me/share', 'POST', {
-                message : message,
-                file : selectedFileInBlob
-            }).then(function(json) {
-                console.log(json);
-            }, function(e) {
-                console.log(e);
-            });
+            if(tweetLen <= 140 && tweetLen > 0) {
+                hello('twitter').api('me/share', 'POST', {
+                    message : message,
+                    file : selectedFileInBlob
+                }).then(function(json) {
+                    console.log(json);
+                }, function(e) {
+                    console.log(e);
+                });
+            }
 
             console.log("Successfully retrieved for "+requestUrl);
         });

--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -73,12 +73,34 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
         }
     };
 
+    // Converts base 64 string to arrayBuffer
+    function _base64ToArrayBuffer(base64) {
+        var binary_string =  window.atob(base64);
+        var len = binary_string.length;
+        var bytes = new Uint8Array( len );
+        for (var i = 0; i < len; i++) {
+            bytes[i] = binary_string.charCodeAt(i);
+        }
+        return bytes.buffer;
+    }
+
+    // Converts an array buffer to base64 strings
+    function _arrayBufferToBase64(uarr) {
+        var strings = [], chunksize = 0xffff;
+        var len = uarr.length;
+
+        for (var i = 0; i * chunksize < len; i++) {
+            strings.push(String.fromCharCode.apply(null, uarr.subarray(i * chunksize, (i + 1) * chunksize)));
+        }
+        return strings.join("");
+    }
+
     // Latitude and Longitude is retrieved and the request is made for the map tile
     function setPosition(position) {
         $rootScope.root.userLocation.latitude = position.coords.latitude;
         $rootScope.root.userLocation.longitude = position.coords.longitude;
-        // Now make a query to loklak
-        var requestUrl = 'http://localhost:9000/vis/map.png?text=Test&mlat='+$rootScope.root.userLocation.latitude+'&mlon='+$rootScope.root.userLocation.longitude+'&zoom=13&width=512&height=256';
+        // Now make a query to loklak for the map tile from the GeoLocation
+        var requestUrl = 'http://localhost:9000/vis/map.png.base64?text=Loklak&mlat='+$rootScope.root.userLocation.latitude+'&mlon='+$rootScope.root.userLocation.longitude+'&zoom=13&width=512&height=256';
         
         $http({
             url: requestUrl,
@@ -87,8 +109,22 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
                 'Content-Type': 'application/json; charset=utf-8'
             }
         }).success(function(response) {
-            var selectedFileInBlob = response;
-            console.log(response);
+
+            var message = $rootScope.root.tweet;
+            var tweetLen = twttr.txt.getTweetLength(message);
+            var tweet = encodeURIComponent(message);
+
+            var selectedFileInBlob = FileService.Base64StrToBlobStr(response);
+
+            hello('twitter').api('me/share', 'POST', {
+                message : message,
+                file : selectedFileInBlob
+            }).then(function(json) {
+                console.log(json);
+            }, function(e) {
+                console.log(e);
+            });
+
             console.log("Successfully retrieved for "+requestUrl);
         });
         // $http.get(requestUrl)

--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -121,6 +121,7 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
                     file : selectedFileInBlob
                 }).then( function (json) {
                     console.log(json);
+                    $('#myModal').modal('hide');
                 }, function(e) {
                     console.log(e);
                 });
@@ -158,6 +159,7 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
                 file: selectedFileInBlob
             }).then( function (json) {
                 console.log(json);
+                $('#myModal').modal('hide');
             }, function (e) {
                 console.log(e);
             });

--- a/app/views/topnav.html
+++ b/app/views/topnav.html
@@ -87,7 +87,7 @@
             <span  class="btn btn-default btn-file fa pull-left">
                 <input type="file" id="fileInput" name="imageUpload" ng-model="root.imageUpload">&nbsp;&#xf030; Add Photo
             </span>
-            <input type="button" class="fa btn btn-info btn-flat pull-left"  ng-click="root.getLocation()" value="&#xf041; Add Location">&nbsp;
+            <input type="button" class="fa btn btn-info btn-flat pull-left"  ng-click="root.getLocation()" value="&#xf041; Tweet with Map Location">&nbsp;
             <input type="submit" class="btn btn-info btn-flat" value="Tweet">&nbsp;
         </div>
         </form>

--- a/app/views/topnav.html
+++ b/app/views/topnav.html
@@ -88,6 +88,7 @@
                 <input type="file" id="fileInput" name="imageUpload" ng-model="root.imageUpload">&nbsp;&#xf030; Add Photo
             </span>
             <input type="button" class="fa btn btn-info btn-flat pull-left"  ng-click="root.getLocation()" value="&#xf041; Tweet with Map Location">&nbsp;
+            <input type="button" class="fa btn btn-info btn-flat pull-left"  ng-click="root.tweetMarkdown()" value="Tweet as Markdown">&nbsp;
             <input type="submit" class="btn btn-info btn-flat" value="Tweet">&nbsp;
         </div>
         </form>


### PR DESCRIPTION
Fixes #355 - Attach map tiles and cross post to twitter via loklak.
Fixes #357 - Gets location information and share location via mobiles.
Fixes #292 - Gets location information via share location via browser.
Fixes #97 , #94 - Successfully uploads markdown content.

Currently in this implementation the new editor isn't implemented, the markdown can be tweeted from the same tweet box except that the buttons have to be clicked accordingly. These will be resolved by the next milestone 3.5 and the tracker for that will be #388 

Tests
1. Type in a tweet and click on tweet with map location.
2. Type in a large text content as follows.

```
Lorem Ipsum is simply dummy text of the 
printing and typesetting industry. Lorem Ipsum 
has been the industry's standard dummy text 
ever since the 1500s, when an unknown printer 
took a galley of type and scrambled it to 
make a type specimen book. It has survived 
not only five centuries, but also the leap into
 electronic typesetting, remaining essentially 
unchanged. It was popularised in the 1960s with
 the release of Letraset sheets containing 
Lorem Ipsum passages, and more recently 
with desktop publishing software like Aldus 
PageMaker including versions of Lorem Ipsum.
```

This should be posting a tweet as an image.
3. The application should ask you to share location to which you have to allow.