### PR TITLE
Add fallback user profile image

### DIFF
--- a/app/js/directives/fallback-src.js
+++ b/app/js/directives/fallback-src.js
@@ -10,6 +10,7 @@ function fallbackSrcDirective(SearchService) {
 			fallbackStatusId: "="
 		},
 		link: function(scope, element, attrs) {
+			scope.errCount = 1;
 			element.bind('error', function() {
 				// Use the placeholder img temporarily
 				attrs.$set('src', attrs.fallbackSrc);
@@ -18,15 +19,18 @@ function fallbackSrcDirective(SearchService) {
 				 * When server-side feature is available, modify retrieveImg service
 			     * and this function call to select the right data.
 				 */
-				// SearchService.retrieveImg(scope.fallbackStatusId)
-				// 	.then(function(data) {
-				// 		attrs.$set('src', data);
-				// 	}, 
-				// 	function(data) {
-				// 		// Do nothing;
-				//      // Keep the playholder;
-				//	    return;
-				// 	});
+				if (scope.errCount === 1) {
+					SearchService.retrieveImg(scope.fallbackStatusId).then(function(data) {
+						if (data.user && data.user.profile_image_url_https) {
+							attrs.$set('src', data.user.profile_image_url_https);
+							console.log(data.user.profile_image_url_https);
+						}
+						scope.errCount += 1;
+					}, 
+					function(data) {
+					    return;
+					});	
+				}
 			});
 		}
 	};

--- a/app/js/services/search.js
+++ b/app/js/services/search.js
@@ -53,10 +53,10 @@ function SearchService($q, $http, AppSettings) {
       return deferred.promise;
   };
 
-  service.retrieveImg = function(statusID) {
+  service.retrieveImg = function(user_screen_name) {
     var deferred = $q.defer();
-    $http.jsonp(AppSettings.apiUrl+'search.json?callback=JSON_CALLBACK', {
-      params: {q : 'id:' + statusID}
+    $http.jsonp(AppSettings.apiUrl+'account.json?callback=JSON_CALLBACK', {
+      params: {screen_name: user_screen_name}
     }).success(function(data) {
         deferred.resolve(data);
     }).error(function(err, status) {
@@ -65,20 +65,6 @@ function SearchService($q, $http, AppSettings) {
 
     return deferred.promise;
   };
-
-  service.getUserInfo = function(username) {
-    var deferred = $q.defer();
-    //paramsObj.q = decodeURIComponent(paramsObj.q);
-    $http.jsonp(AppSettings.apiUrl+'account.json?callback=JSON_CALLBACK', {
-      params: {screen_name: username}
-    }).success(function(data) {
-        deferred.resolve(data);
-    }).error(function(err, status) {
-        deferred.reject(err, status);
-    });
-
-    return deferred.promise;
-  }
 
   return service;
 


### PR DESCRIPTION
Solve #59. With the new account servlet, this is now possible.

How to check
- Try out with different search term on live, look for this fallback img
![image](https://cloud.githubusercontent.com/assets/6878677/8897944/1953ac46-3426-11e5-9036-f1275f405b31.png), it's faster to use account filter, for example:
   - http://test.loklak.net/search?q=%23foo%2B%2Faccounts
- Then try the same thing with the local server, look if the fallback is replaced with the user image
   - http://localhost:3001/search?q=%23foo%2B%2Faccounts
 (to quickly see if any fallback method is called, dive to the console, you should see logs of the image url
![image](https://cloud.githubusercontent.com/assets/6878677/8898004/b7cc42f2-3426-11e5-8cda-be79e80c2291.png)

Remember to define all of the twitter credentials in server config 
![image](https://cloud.githubusercontent.com/assets/6878677/8898021/df33b0fa-3426-11e5-8263-1ebf2ad66606.png)
