### PR TITLE
LineSplit Mode active in markdown editor rendering via pre

### DIFF
--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -81,7 +81,7 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
                 var tempArr = [];
 
                 for (var line = 0; line < lines.length; line++) {
-                    tempArr.push(lines[line].innerHTML);
+                    tempArr.push(lines[line].textContent);
                 }
 
                 var attachmentText = tempArr.join('\n');

--- a/app/js/controllers/tweet.js
+++ b/app/js/controllers/tweet.js
@@ -77,10 +77,11 @@ controllersModule.controller('HomeCtrl', ['$rootScope', 'HelloService', 'FileSer
             }
             else if (optionChosen === 'markdownAttachment') {
                 console.log("Markdown Attachment going on here.");
-
+                var lines =  $('.CodeMirror-code > pre')
                 var tempArr = [];
-                for (var i=0; i<= $('.CodeMirror-code').text().length; i+=80) {
-                    tempArr.push($('.CodeMirror-code').text().substring(i,i+80));   
+
+                for (var line = 0; line < lines.length; line++) {
+                    tempArr.push(lines[line].innerHTML);
                 }
 
                 var attachmentText = tempArr.join('\n');


### PR DESCRIPTION
Previously the contents of the markdown box were taken at a fixed length at a time, Now they're taken line by line automatically so that the markdown servlet can render the image accordingly.

Please review and merge @prasht63 This is a very minor fix but fixes the line by line problem and better markdown text being rendered.