### PR TITLE
Wall map enhancements

### DIFF
--- a/app/js/controllers/wallDisplay.js
+++ b/app/js/controllers/wallDisplay.js
@@ -93,8 +93,6 @@ function WallDisplay($scope, $stateParams, $interval, $timeout, $location, $http
     function getWallData(){
         vm.wallOptions = AppsService.get({user:$stateParams.user, app:'wall', id: $stateParams.id});
         vm.wallOptions.$promise.then(function(data){
-            console.log("this is");
-            console.log(vm.wallOptions);
             if(vm.wallOptions.id){
                 if (vm.wallOptions.layoutStyle == '1') {
                     maxStatusCount = 10; //linear

--- a/app/js/directives/mapLayout.js
+++ b/app/js/directives/mapLayout.js
@@ -117,7 +117,7 @@ function mapLayoutDirective(MapPopUpTemplateService, $interval, $location, MapCr
                             });
                             tempMarker.addTo(map);
                             var popup = L.popup({
-                                autoPan: true
+                                autoPan: false
                             }).setContent("<div class='foobar'>" + text + "</div>");
                             tempMarker.bindPopup(popup);
                             ele.marker = tempMarker;
@@ -146,7 +146,7 @@ function mapLayoutDirective(MapPopUpTemplateService, $interval, $location, MapCr
                     }
                 }
                 setTimeout(function() {
-                    //tweetsArray[0].marker.openPopup();
+                    tweetsArray[0].marker.openPopup();
                 }, 1000);
             });
 

--- a/app/js/directives/mapLayout.js
+++ b/app/js/directives/mapLayout.js
@@ -9,7 +9,7 @@ var bouncemarker = require('../components/bouncemarker');
 /**
  * @ngInject
  */
-function mapLayoutDirective(MapPopUpTemplateService, $interval, MapCreationService) {
+function mapLayoutDirective(MapPopUpTemplateService, $interval, $location, MapCreationService) {
 
     return {
         scope: {
@@ -27,7 +27,38 @@ function mapLayoutDirective(MapPopUpTemplateService, $interval, MapCreationServi
             if (typeof(cycle) == 'undefined' || cycle == null) {
                 cycle = false;
             }
-            var map = L.map(attrs.id).setView([2.252776, 48.845261], 3);
+            var centerLat = 2.252776;
+            var centerLng = 48.845261;
+            var zoom = 3;
+            var queryParams = $location.search();
+            function isValidLat(x){
+                //to be added
+                return true;
+            }
+            function isValidLng(x){
+                //to be added
+                return true;
+            }
+            function isValidZoom(x){
+                //to be added
+                return true;
+            }
+            if(queryParams.lat){
+                if(isValidLat(queryParams.lat)){
+                    centerLat = queryParams.lat;
+                }
+            }
+            if(queryParams.lng){
+                if(isValidLng(queryParams.lng)){
+                    centerLng = queryParams.lng;
+                }
+            }
+            if(queryParams.zoom){
+                if(isValidZoom(queryParams.zoom)){
+                    zoom = queryParams.zoom;
+                }
+            }
+            var map = L.map(attrs.id).setView([centerLat, centerLng], zoom);
             L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
                 maxZoom: 18,
                 attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
@@ -44,6 +75,12 @@ function mapLayoutDirective(MapPopUpTemplateService, $interval, MapCreationServi
                         animate: true
                     }); // pan to new center
                 }
+            });
+
+            map.on('moveend', function(e) {
+                var center = map.getCenter();
+                var path = $location.path();
+                $location.path(path).search({'lat':center.lat,'lng':center.lng,'zoom':map.getZoom()});
             });
 
             function contains(elem) {
@@ -109,7 +146,7 @@ function mapLayoutDirective(MapPopUpTemplateService, $interval, MapCreationServi
                     }
                 }
                 setTimeout(function() {
-                    tweetsArray[0].marker.openPopup();
+                    //tweetsArray[0].marker.openPopup();
                 }, 1000);
             });
 
@@ -133,4 +170,4 @@ function mapLayoutDirective(MapPopUpTemplateService, $interval, MapCreationServi
 
 }
 
-directivesModule.directive('maplayout', ['MapPopUpTemplateService', '$interval', 'MapCreationService', mapLayoutDirective]);
+directivesModule.directive('maplayout', ['MapPopUpTemplateService', '$interval', '$location', 'MapCreationService', mapLayoutDirective]);

--- a/app/views/wall/display.html
+++ b/app/views/wall/display.html
@@ -32,7 +32,7 @@
                 <div ng-switch-when="2" class="animate-repeat" ng-repeat="status in wall.statuses" card open="wall.open" data="status" leaderboardEnabled="{{wall.wallOptions.showStatistics}}"></div>
                 <div ng-switch-when="3" class="animate-repeat" ng-repeat="status in wall.statuses" coa open="wall.open" data="status"></div>
                 <div ng-switch-when="4">
-                    <div data="wall.statuses" id="map" maplayout style="margin-left:-48px; margin-top:-10px;" ng-style="wall.wallOptions.showStatistics?{}:{'margin-right':'-48px'}"></div>
+                    <div data="wall.statuses" id="map" maplayout style="margin-left:-48px; margin-top:-10px;" ng-style="wall.wallOptions.showStatistics?{}:{'margin-right':'-48px'}" cycleTweets="{{wall.wallOptions.cycle}}"></div>
                 </div>
             </div>
             <div ng-if="wall.wallOptions.showStatistics && wall.statuses.length>0" class="col-md-4">

--- a/app/views/wall/wallCreationModal.html
+++ b/app/views/wall/wallCreationModal.html
@@ -107,9 +107,22 @@
                                                 <div class="form-group row">
                                                     <h4 class="col-xs-9">Cycle/Repeat tweets
                                                             <br><small>Do you want to constantly cycle Tweets so it always appears active? Will show only latest tweets if set to No.</small></h4>
-                                                    <toggle-switch disabled="true" class="wall-toggle-switch" on-label="YES" off-label="NO" ng-model="newWallOptions.cycle">
+                                                    <toggle-switch class="wall-toggle-switch" on-label="YES" off-label="NO" ng-model="newWallOptions.cycle">
                                                     </toggle-switch>
                                                 </div>
+                                                <!-- <hr>
+                                                <div ng-if="newWallOptions.cycle==true" class="form-group row">
+                                                    <h4 class="col-xs-9">Cycle Delay Time
+                                                            <br><small>When there are no new posts, show a tweet for how many seconds?</small></h4>
+                                                    <input style="min-width:100px;width:10%;" class="col-xs-2" type="number" ng-model="newWallOptions.cycleDelayTime">
+                                                    <hr>
+                                                </div>
+                                                <div ng-if="newWallOptions.cycle==true" class="form-group row">
+                                                    <h4 class="col-xs-9">Cycle Post Limit
+                                                            <br><small>How many of the most recent posts should we cycle?</small></h4>
+                                                    <input style="min-width:100px;width:10%;" class="col-xs-2" type="number" ng-model="newWallOptions.cyclePostLimit">
+                                                    <hr>
+                                                </div> -->
                                                 <hr>
                                                 <div class="form-group">
                                                     <h3>Which media do you want to show on the wall?</h3>
@@ -135,8 +148,8 @@
                                                     <h3>Location</h3>
                                                     <div class="row">
                                                         <h4 class="col-xs-8">Places<br><small>Show tweets near this place</small></h4>
-                                                        <input class="wall-location-input"  type="text" ng-model="newWallOptions.chosenLocation">
-                                                        <ul class="col-xs-offset-8 wall-location-list"  ng-show="wall.hasSuggestions">
+                                                        <input class="wall-location-input" type="text" ng-model="newWallOptions.chosenLocation">
+                                                        <ul class="col-xs-offset-8 wall-location-list" ng-show="wall.hasSuggestions">
                                                             <li ng-repeat="location in wall.locationSuggestions | limitTo:5" ng-click="wall.setLocation(location.query)">{{location.query}}</li>
                                                         </ul>
                                                     </div>


### PR DESCRIPTION
When the map is dragged/panned/moved/etc the coordinates of the center and the zoom level is added to the URL. This URL can now be shared, and when this wall-map opens, it takes the values from the URL. Use case: Person creates a wall-map for cccamp15, sets "Cycle tweets" to "No" and pans and zooms the map so the desired map is shown. Now, the person can directly share the URL and the center coordinates and zoom level will be preserved. However, this new state is not saved as a part of the wall object. 
Example: http://aneesh-ojl02abl.cloudapp.net/aneeshd16/wall/VJRDSK_c?lat=50.49246334187725&lng=9.73388671875&zoom=6