### PR TITLE
Allow Unlimited Tags during Wall Creating

### DIFF
--- a/app/styles/_wall.scss
+++ b/app/styles/_wall.scss
@@ -143,7 +143,7 @@
 }
 
 .wall-tag-input {
-    height: 60px;
+    min-height: 60px;
     outline: none !important;
     border: 0px solid transparent !important;
     padding: 5px;


### PR DESCRIPTION
* Changed `height: 60px` to `min-height: 60px` so that when tags occupy more than 2 lines, the box expands accordingly

![Current Version](https://cloud.githubusercontent.com/assets/1736001/11917007/00cf088e-a71a-11e5-9881-4d8f98d5987d.png)

Fixed #543 
