### PR TITLE
Bfix(#580): Fixes spaces between inline search-filters

### DIFF
--- a/app/styles/_search.scss
+++ b/app/styles/_search.scss
@@ -1064,6 +1064,7 @@
 		ul {
 			margin-left: 0 !important;
 			padding-left: 0 !important;
+			font-size: 0;
 		}
 		ul li {
 			display: inline-block;


### PR DESCRIPTION
Earlier buggy view!
![afb34792-eb9f-11e5-8acc-a644496200c7](https://cloud.githubusercontent.com/assets/6399612/13954672/cd401e62-f067-11e5-88b1-d3451c2e53b6.png)

Fixed view as given below!
![screenshot from 2016-03-16 18 06 23](https://cloud.githubusercontent.com/assets/6399612/13812385/d5b4c3ba-eba1-11e5-8b10-b29d7d0cdb7a.png)
![screenshot from 2016-03-16 18 06 21]
