### PR TITLE
Fix #577 | Current view topnav item now being highlighted | Reopen

### DIFF
--- a/app/js/on_run.js
+++ b/app/js/on_run.js
@@ -6,7 +6,7 @@
  * @ngInject
  */
 function OnRun($rootScope, AppSettings, HelloService) {
-	var root = {};
+  var root = {};
   root.hello = HelloService;
   
   /**
@@ -15,11 +15,11 @@ function OnRun($rootScope, AppSettings, HelloService) {
    */
     root.globalSearchTerm = '';
     root.topNavItems = [
-    		{
-    			'title': 'Home',
-    			'link' : '/',
+        {
+          'title': 'Home',
+          'link' : '/',
           'icon' : 'fa fa-home'
-    		},
+        },
         {
           'title': 'Report',
           'link' : '/report',
@@ -36,7 +36,7 @@ function OnRun($rootScope, AppSettings, HelloService) {
           'icon' : 'fa fa-cloud'
         }
         
-  	  ];
+      ];
 
     root.fullscreenDisabled = true;
     root.sidebarEnabled = false;
@@ -55,9 +55,16 @@ function OnRun($rootScope, AppSettings, HelloService) {
       var pageTitle = 'Loklak ';
       if ( toState.title ) {
         pageTitle += toState.title;
-        $rootScope.root.currentView = toState.title;
       }
       $rootScope.root.pageTitle = pageTitle;
+
+      if (toState.currentView) {
+        $rootScope.root.currentView = toState.currentView;
+      } else {
+        if ( toState.title ) {
+          $rootScope.root.currentView = toState.title;
+        }
+      }
     });
     $rootScope.root = root;
 }

--- a/app/js/routes.js
+++ b/app/js/routes.js
@@ -11,7 +11,8 @@ function Routes($stateProvider, $locationProvider, $urlRouterProvider, $httpProv
     url: '/',
     controller: 'MapCtrl as map',
     templateUrl: 'home.html',
-    title: 'Home'
+    title: 'Home',
+    currentView: 'Home'
   })
   .state('About', {
     url: '/about',
@@ -36,7 +37,8 @@ function Routes($stateProvider, $locationProvider, $urlRouterProvider, $httpProv
     url: '/wall',
     templateUrl: 'wall/create.html',
     controller: 'WallCtrl as wall',
-    title: 'Wall'
+    title: 'Wall',
+    currentView: 'Wall'
   })
   // .state('WallCreate', {
   //   url: '/wall/create',
@@ -74,7 +76,8 @@ function Routes($stateProvider, $locationProvider, $urlRouterProvider, $httpProv
     url: '/connect',
     templateUrl: 'data-connect/data-connect.html',
     controller: 'DataConnectCtrl as dataConnect',
-    title: 'My Connections'
+    title: 'My Connections',
+    currentView: 'Connect'
   })
   .state('DataConnectWSourceType', {
     url: '/connect/:source_type',
@@ -86,7 +89,8 @@ function Routes($stateProvider, $locationProvider, $urlRouterProvider, $httpProv
     url: '/report',
     templateUrl: 'analyze/analyze.html',
     controller: 'AnalyzeCtrl as Analyze',
-    title: 'Analyze Data'
+    title: 'Analyze Data',
+    currentView: 'Report'
   })
   .state('Redirecting', {
     url: '/redirect',


### PR DESCRIPTION
This is fix for Issue #577 
So the problem was, in app/views/topnav.html (line 12-14),  
```html
<li ng-repeat="navItem in root.topNavItems">
    <a ng-class="(navItem.title == root.currentView) ? 'active-view-nav' : ''" ng-href="{{navItem.link}}"><span class="{{navItem.icon}}"></span><span class="nav-item-title">{{navItem.title}}</span></a>
</li>
```
And here `root.currentView` comes from watch function for change of state in app/js/on_run.js where currentView was set as state.title but that title is not same as the nav title so the issue was occurring!

I have created currentView element in required states and set `$rootScope.root.currentView = toState.currentView;`


Note: As asked by @sudheesh001, I have squashed the changes into single commit. And reopened the Pull Request #578.