### PR TITLE
[DO NOT MERGE] Wiki Geo Data API controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Install and run it first.
 
 ### Build
 
-1. Install: git npm nodejs nasm libpng-dev dh-autoreconf
-2. run `npm install -g gulp`
+1. Install the following: `git`, `npm`, `nodejs`, `nasm`, `libpng-dev` and `dh-autoreconf`.
+2. Run as root or administrator `npm install -g gulp`
 3. Clone this repo from `https://github.com/loklak/loklak_webclient.git`
 4. Create your custom settings file by doing
    `cp configFile.json custom_configFile.json`.
@@ -20,11 +20,9 @@ Install and run it first.
 5. Run `npm install` from the root directory **AND** from `oauth-proxy` subdirectory, **AND** from `iframely`
 
 ### Add twitter credentials
-Create an twitter application at `https://apps.twitter.com`, remember to set the correct website url & callback url (for localhost, `http://127.0.0.1/` works better), then modify `custom_configFile.json`:
-1. Set the twitterConsumerKey var in `custom_configFile.json`
-  to set the Consumer Key (API Key) from your Twitter app
-2. Set the twitterConsumerSecret var in `custom_configFile.json`
-  to set the Consumer Secret from your Twitter app  
+Create a Twitter application at [https://apps.twitter.com](https://apps.twitter.com), remember to set the correct website url & callback url (for localhost, `http://127.0.0.1/` works better), then modify `custom_configFile.json`:
+* Set the twitterConsumerKey var in `custom_configFile.json` to set the Consumer Key (API Key) from your Twitter app
+* Set the twitterConsumerSecret var in `custom_configFile.json` to set the Consumer Secret from your Twitter app  
 
 A twitter app is valid only for a domain (defined when creating the app). So the credentails above need to be changed also according to the domain (e.g. you'll need to create 2 twitter apps separately for a clone in localhost and for a clone in a remote server)
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ Install and run it first.
 
 ### Build
 
-1. Install the following: `git`, `npm`, `nodejs`, `nasm`, `libpng-dev` and `dh-autoreconf`.
-2. Run as root or administrator `npm install -g gulp`
+1. Install `git`, `npm`, `nodejs`, `nasm`, `libpng-dev` and `dh-autoreconf`packages. 
+   Run the commands as:
+   * `sudo apt-get install git-core`
+   * `sudo apt-get install npm`
+   * `sudo apt-get install nodejs`
+   * `sudo apt-get install nasm`
+   * `sudo apt-get install libpng-dev`
+   * `sudo apt-get install dh-autoreconf`
+2. Run `sudo npm install -g gulp` to install `gulp` systemwide as a tool to run the task.
 3. Clone this repo from `https://github.com/loklak/loklak_webclient.git`
 4. Create your custom settings file by doing
    `cp configFile.json custom_configFile.json`.

--- a/app/js/controllers/wikiGeoDataAPI.js
+++ b/app/js/controllers/wikiGeoDataAPI.js
@@ -1,0 +1,46 @@
+/**
+ *  Wiki GeoData API
+ *  https://www.mediawiki.org/wiki/Extension:GeoData#API
+ *  By Jigyasa Grover, jig08
+ */
+
+'use strict';
+/* global angular, L, map */
+/* jshint unused:false */
+
+var controllersModule = require('./_index');
+/**
+ * @ngInject
+ */
+
+controllersModule.controller('WikiGeoDataController', ['$scope', '$http', '$sce', function($scope, $http, $sce) {
+
+			/*
+				Returns pageIDs of articles around the given point (determined either by coordinates and radius).
+				The wiki article can then be accessed by https://en.wikipedia.org/?curid=<pageID>
+			*/
+
+            $scope.wikiGeoData = function() {               
+
+                var baseURL = 'https://en.wikipedia.org/w/api.php?';
+                var lat; //Lattitude of the place
+                var lon; //Longitude of the place
+                var radius = 1000;
+                var QueryCommand = baseURL + "action=query&prop=info&list=geosearch&gscoord=" + lat + "|" + lon + "&gsradius=" + radius + "format=json";
+
+                $http.get(String(QueryCommand)).then(function(response) {
+                    console.log(response.data.query.geosearch[0].pageid);
+                    $scope.geoData = response.data.geosearch;
+
+                    for (var i = 0; i < $scope.geoData.length; ++i) {
+                        $scope.geoData[i].pageid = $sce.trustAsHtml($scope.geoData[i].pageid);
+                    }
+                    
+                    /*
+                    	The wiki article can then be accessed by https://en.wikipedia.org/?curid=<pageID>
+                    */
+                });
+
+            }
+
+        }]);


### PR DESCRIPTION
A JS controller for [Wiki GeoData AP](https://www.mediawiki.org/wiki/Extension:GeoData#API)I has been created for [loklak.net](http://loklak.net/)

This returns a JSON object of a list of articles around the given point (determined by coordinates and radius) whose one of the parameters `pageid` can be used to access the Wiki Article via `https://en.wikipedia.org/?curid=<pageid>`

_Yet to be done: Pass the `lat`(latitude) and `lon`(longitude) of the location in the `QueryCommand`._

Let me know your views, so that this can be modified accordingly.